### PR TITLE
Add the mysqli and curl PHP exts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -63,7 +63,8 @@ cp secure-db-connection/lib/db.php ./wordpress/wp-content/db.php
 # Setup the working directory
 mkdir wordpress/.bp-config;
 echo "{
-    \"WEBDIR\": \"/\"
+    \"WEBDIR\": \"/\",
+    \"PHP_EXTENSIONS\": [\"mysqli\", \"curl\"]
 }" > wordpress/.bp-config/options.json;
 
 # Write the wp-config.php


### PR DESCRIPTION
These enable wordpress to connect to the database and make API calls (the installation process relies on being able to hit a translations API)